### PR TITLE
AndroidStudioの更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # iTube-android
 
-![Android Studio](https://img.shields.io/badge/Android%20Studio-3.6%20Canary06-green.svg)
+![Android Studio](https://img.shields.io/badge/Android%20Studio-3.6%20Canary07-green.svg)
 ![Kotlin](https://img.shields.io/badge/kotlin-1.3.50-yellow.svg)
 
 ## About  

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0-alpha06'
+        classpath 'com.android.tools.build:gradle:3.6.0-alpha07'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath 'com.cookpad.android.licensetools:license-tools-plugin:1.2.0'
     }


### PR DESCRIPTION
## Overview 
- Title says it all.  

https://androidstudio.googleblog.com/2019/08/android-studio-36-canary-7-available.html